### PR TITLE
Add unit declarator to class declarations

### DIFF
--- a/lib/Cache/Memcached.pm
+++ b/lib/Cache/Memcached.pm
@@ -1,7 +1,7 @@
 use v6;
 use String::CRC32;
 
-class Cache::Memcached:auth<cosimo>:ver<0.04>;
+unit class Cache::Memcached:auth<cosimo>:ver<0.04>;
 
 =begin pod
 use Storable ();


### PR DESCRIPTION
As of Rakudo 2015.05, the `unit` declarator is required before using
`module`, `class` or `grammar` declarations (unless it uses a block).  Code
still using the old blockless semicolon form will throw a warning. This
commit stops the warning from appearing in the new Rakudo.