### PR TITLE
Bring that up to working with the current rakudo

### DIFF
--- a/lib/Cache/Memcached.pm
+++ b/lib/Cache/Memcached.pm
@@ -485,7 +485,7 @@ method sock_to_host (Str $host) {
     my $port;
 
     if $host ~~ m/ (.*) \: (\d+) / {
-        $ip = $0;
+        $ip = $0.Str;
         $port = $1.Int;
         # Get rid of optional IPv6 brackets
         $ip ~~ s:g [ \[ | \] ] = '' if $ip.defined;
@@ -745,7 +745,7 @@ method _write_and_read (IO::Socket $sock, Str $command, Mu $check_complete?) {
 =end oldpart
 
         if $to_send > 0 {
-            my $sent = $sock.send($line);
+            my $sent = $sock.print($line);
             if $sent == 0 {
                 self._close_sock($sock);
                 return;

--- a/t/010_internals.t
+++ b/t/010_internals.t
@@ -46,7 +46,7 @@ like($lines, /VERSION/, "got version back");
 lives-ok { $lines = $memd._write_and_read($sock, "stats\r\n") }, "_write_and_read";
 
 
-done();
+done-testing();
 
 
 # vim: ft=perl6

--- a/t/030_stats.t
+++ b/t/030_stats.t
@@ -46,4 +46,4 @@ for @misc_stats_keys -> $stat_key  {
        "misc stats hosts $testaddr misc contains $stat_key");
 }
 
-done();
+done-testing();

--- a/t/040_noreply.t
+++ b/t/040_noreply.t
@@ -57,4 +57,4 @@ is($memd.get("key"), count + 1 * count);
 $memd.delete("key");
 is($memd.get("key"), Nil);
 
-done();
+done-testing();

--- a/t/050_reconnect_timeout.t
+++ b/t/050_reconnect_timeout.t
@@ -38,4 +38,4 @@ $memd.set("key", "foo");
 my $time3 = now;
 ok($time3 - $time2 < .1, "Should return fast on retry");
 
-done();
+done-testing();

--- a/t/060_utf8_key.t
+++ b/t/060_utf8_key.t
@@ -28,4 +28,4 @@ my $key = "Ïâ";
 ok($memd.set($key, "val1"), "set key1 as val1");
 is($memd.get($key), "val1", "get key1 is val1");
 
-done();
+done-testing();

--- a/t/100_flush_bug.t
+++ b/t/100_flush_bug.t
@@ -54,4 +54,4 @@ for @res <-> $v {
     is $memd.flush_all, $v[1], $v[0];
 }
 
-done();
+done-testing();

--- a/t/999_connect.t
+++ b/t/999_connect.t
@@ -29,4 +29,4 @@ ok(my $rv = $mc.set("mykey", "myvalue"), "set value");
 $rv = $mc.get("mykey");
 is($rv, "myvalue", "get() should get back the same value");
 
-done();
+done-testing();


### PR DESCRIPTION
Hi,
there was only a little bit of bit-rot in that, All working again:

```
Test Summary Report
-------------------
t/050_reconnect_timeout.t (Wstat: 0 Tests: 2 Failed: 0)
  TODO passed:   2
Files=9, Tests=76, 35 wallclock secs ( 0.07 usr  0.01 sys + 34.11 cusr  0.58 csys = 34.77 CPU)
Result: PASS
```

